### PR TITLE
Change file ending of connection file from .ini to .vv

### DIFF
--- a/public/index.php
+++ b/public/index.php
@@ -295,7 +295,7 @@ $app->get('/getSpiceConfig/:i', function($instance) use ($app) {
 	$inst = $g->getInstance($instance);
 	
 	Header("Content-Type: application/x-virt-viewer");
-	header("Content-disposition: attachment; filename=spice-connection.ini");
+	header("Content-disposition: attachment; filename=spice-connection.vv");
 	echo "[virt-viewer]\n";
         echo "type=spice\n";
 	echo "host=" . $inst["pnode"] . "\n";


### PR DESCRIPTION
On unix systems without a full blown desktop environment xdg-utils
behave somewhat dumb and spit out a mime-type based solely on the file
ending. As chromium uses xdg-open for opening files (Firefox has it's
own logic), it will open the spice-connection.ini in the text editor
instead of Remote Viewer.

To make chromium open Remote Viewer directly without needing further
configuration, change the file ending to .vv, which is the official file
ending for these files anyway.

```
~ > md5sum spice-connection.*
985639f5eb82fa5b62471faa74d92ee0  spice-connection.ini
985639f5eb82fa5b62471faa74d92ee0  spice-connection.vv
~ > mimetype spice-connection.*
spice-connection.ini: text/plain
spice-connection.vv:  application/x-virt-viewer
```